### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK
       uses: actions/setup-java@v2
       with:
         java-version: '16'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn verify -Ddocker_host=localhost

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn verify -Ddocker_host=localhost
+      run: mvn verify -Dit=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: '16'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # spring-boot-tests
 ## Run Tests
 ```
-mvn verify -Ddocker_host=localhost
+mvn verify -Dit=true
+
+# docker daemon host can be customized with: -Ddocker_host=unix:///var/run/docker.sock
 ```
 
 ## Start/Stop containers for IDE tests running
 ```
-mvn docker:start -Ddocker_host=localhost
-mvn docker:stop -Ddocker_host=localhost
+mvn docker:start -Dit=true
+mvn docker:stop -Dit=true
+
+# Docker Daemon host can be customized with: -Ddocker_host=unix:///var/run/docker.sock
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ```
 mvn verify -Dit=true
 
-# docker daemon host can be customized with: -Ddocker_host=unix:///var/run/docker.sock
+# Docker Daemon host can be customized with: -Ddocker_host=unix:///var/run/docker.sock
 ```
 
 ## Start/Stop containers for IDE tests running

--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,14 @@
             <id>it</id>
             <activation>
                 <property>
-                    <name>docker_host</name>
+                    <name>it</name>
+                    <value>true</value>
                 </property>
             </activation>
             <properties>
                 <docker_port>2375</docker_port>
+                <postgres_host>0.0.0.0</postgres_host>
                 <postgres_port>5432</postgres_port>
-
             </properties>
             <build>
                 <plugins>
@@ -114,7 +115,7 @@
                         <configuration>
                             <environmentVariables>
                                 <spring.profiles.active>tests-remote</spring.profiles.active>
-                                <postgres_host>${docker_host}</postgres_host>
+                                <postgres_host>${postgres_host}</postgres_host>
                                 <postgres_port>${postgres_port}</postgres_port>
                             </environmentVariables>
                         </configuration>
@@ -141,7 +142,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <dockerHost>tcp://${docker_host}:${docker_port}</dockerHost>
+                            <dockerHost>${docker_host}</dockerHost>
                             <images>
                                 <image>
                                     <name>postgres:11</name>


### PR DESCRIPTION
* This PR adds a simple CI job with Github Actions, which runs integration tests
* A couple of improvements:
  - Activate the it profile with `-Dit=true`
  - Default value for `docker_host` is implicitly set to `unix:///var/run/docker.sock`, which should work out of the box on Unix & Mac OSX (see [documentation](https://dmp.fabric8.io/#global-configuration))
  - `docker_host` can be overridden with: `-Ddocker_host=tcp://192.168.59.103:2375`